### PR TITLE
update quicklytest.sh 增加部分模式下的Route-Path打印

### DIFF
--- a/quicklytest.sh
+++ b/quicklytest.sh
@@ -81,9 +81,6 @@ check_mode() {
                 TRACECMD=${TRACECMD}" -rdns -realtime"
     fi
     
-    return 0
-    #未实现的功能:
-    ask_if "是否升级脚本？(y/n)" && update_script
     echo -e "${Info} 是否输出Route-Path?" 
     ask_if "输入y/n以选择模式:" && TRACECMD=${TRACECMD}" -report"
 }

--- a/quicklytest.sh
+++ b/quicklytest.sh
@@ -77,12 +77,21 @@ check_mode() {
     echo -e "${Info} 结果是否制表?(制表模式为非实时显示)" 
     if ask_if "输入y/n以选择模式:" ; then
                 TRACECMD=${TRACECMD}" -rdns -table"
-    else
+                ##Route-Path功能还未完善,临时替代:
+                [[ "${node}" == "2" ]] && TRACECMD=${TRACECMD}" -report"
+                ##
+    else        
                 TRACECMD=${TRACECMD}" -rdns -realtime"
+                ##Route-Path功能还未完善,临时替代:
+                [[ "${node}" == "1" ]] && TRACECMD=${TRACECMD}" -report"
+                ##
     fi
     
-    echo -e "${Info} 是否输出Route-Path?" 
-    ask_if "输入y/n以选择模式:" && TRACECMD=${TRACECMD}" -report"
+    #echo -e "${Info} 是否输出Route-Path?" 
+    #ask_if "输入y/n以选择模式:" && TRACECMD=${TRACECMD}" -report"
+    
+    
+    
 }
 
 test_single() {


### PR DESCRIPTION
1. TCP 目前已具备在-table模式下打印Route-Path [update: 现在TCP SYN模式下也将打印路由跟踪结果](https://github.com/xgadget-lab/nexttrace/commit/b20b27fd20fa1f8a4caa110798ae6f468c7cb7ee)

2. ICMP之前就已具备在-realtime模式下打印Route-Path

所以将quicklytest.sh调整为: 在前面提到2种情况下, 默认打印Route-Path


